### PR TITLE
Fix package linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ The Standard Notes Web App. An end-to-end encrypted note-taking app. Web, Mac, W
 
 ## Disclaimers / important information
 
-* Any known limitations, constrains or stuff not working, such as (but not limited to):
-    * No single-sign on or LDAP integration
-    * The app requires up 1500MB of RAM to install
-    * The app requires at least 80MB of RAM to work properly.
-    * The app requires around 1000MB of disk.
-    * A dedicated domain is requierd if you want to use extensions.
-        * notes.your-domain.tld/ -> Extension Manager is working
-        * your-domain.tld/notes/ -> Extension Manager is not working
+* No single-sign on or LDAP integration
+* The app requires up 1500MB of RAM to install
+* The app requires at least 80MB of RAM to work properly.
+* The app requires around 1000MB of disk.
 
-* Other infos that people should be aware of, such as:
-    * The config-file is stored under "/opt/yunohost/$app/live/.env"
+* A dedicated domain is requierd if you want to use extensions.
+    * notes.your-domain.tld/ -> Extension Manager is working
+    * your-domain.tld/notes/ -> Extension Manager is not working
+
+* The config-file is stored under "/opt/yunohost/$app/live/.env"
 
 ## Documentation and resources
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,17 +23,16 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 ## Avertissements / informations importantes
 
-* Any known limitations, constrains or stuff not working, such as (but not limited to):
-    * No single-sign on or LDAP integration
-    * The app requires up 1500MB of RAM to install
-    * The app requires at least 80MB of RAM to work properly.
-    * The app requires around 1000MB of disk.
-    * A dedicated domain is requierd if you want to use extensions.
-        * notes.your-domain.tld/ -> Extension Manager is working
-        * your-domain.tld/notes/ -> Extension Manager is not working
+* No single-sign on or LDAP integration
+* The app requires up 1500MB of RAM to install
+* The app requires at least 80MB of RAM to work properly.
+* The app requires around 1000MB of disk.
 
-* Other infos that people should be aware of, such as:
-    * The config-file is stored under "/opt/yunohost/$app/live/.env"
+* A dedicated domain is requierd if you want to use extensions.
+    * notes.your-domain.tld/ -> Extension Manager is working
+    * your-domain.tld/notes/ -> Extension Manager is not working
+
+* The config-file is stored under "/opt/yunohost/$app/live/.env"
 
 ## Documentations et ressources
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,11 +3,6 @@ location __PATH__/ {
   # Path to source
   alias __FINALPATH__/live/public ;
 
-  # Force usage of https
-  if ($scheme = http) {
-    rewrite ^ https://$server_name$request_uri? permanent;
-  }
-
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 25M;
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,11 +1,10 @@
-* Any known limitations, constrains or stuff not working, such as (but not limited to):
-    * No single-sign on or LDAP integration
-    * The app requires up 1500MB of RAM to install
-    * The app requires at least 80MB of RAM to work properly.
-    * The app requires around 1000MB of disk.
-    * A dedicated domain is requierd if you want to use extensions.
-        * notes.your-domain.tld/ -> Extension Manager is working
-        * your-domain.tld/notes/ -> Extension Manager is not working
+* No single-sign on or LDAP integration
+* The app requires up 1500MB of RAM to install
+* The app requires at least 80MB of RAM to work properly.
+* The app requires around 1000MB of disk.
 
-* Other infos that people should be aware of, such as:
-    * The config-file is stored under "/opt/yunohost/$app/live/.env"
+* A dedicated domain is requierd if you want to use extensions.
+    * notes.your-domain.tld/ -> Extension Manager is working
+    * your-domain.tld/notes/ -> Extension Manager is not working
+
+* The config-file is stored under "/opt/yunohost/$app/live/.env"

--- a/manifest.json
+++ b/manifest.json
@@ -31,8 +31,7 @@
         "install": [
             {
                 "name": "domain",
-                "type": "domain",
-                "example": "example.com"
+                "type": "domain"
             },
             {
                 "name": "path",

--- a/scripts/install
+++ b/scripts/install
@@ -161,10 +161,10 @@ pushd "$final_path/live"
     ynh_use_nodejs
     ynh_exec_as $app $ynh_ruby_load_path bin/bundle config set --local path 'vendor/bundle'
     ynh_exec_as $app $ynh_ruby_load_path bin/bundle config set with 'development'
-    ynh_exec_warn_less "ynh_exec_as $app $ynh_ruby_load_path bin/bundle install -j$(getconf _NPROCESSORS_ONLN) --quiet"
-    ynh_exec_warn_less "ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile"
-    ynh_exec_warn_less "ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn bundle"
-    ynh_exec_warn_less "ynh_exec_as $app $ynh_ruby_load_path bin/bundle exec rails assets:precompile --quiet"
+    ynh_exec_warn_less ynh_exec_as $app $ynh_ruby_load_path bin/bundle install -j$(getconf _NPROCESSORS_ONLN) --quiet
+    ynh_exec_warn_less ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+    ynh_exec_warn_less ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn bundle
+    ynh_exec_warn_less ynh_exec_as $app $ynh_ruby_load_path bin/bundle exec rails assets:precompile --quiet
 popd
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -37,8 +37,6 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #=================================================
 ynh_script_progression --message="Validating restoration parameters..." --weight=1
 
-ynh_webpath_available --domain=$domain --path_url=$path_url \
-	|| ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die --message="There is already a directory: $final_path "
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -181,10 +181,10 @@ then
 		ynh_use_nodejs
 		ynh_exec_as $app $ynh_ruby_load_path bin/bundle config set --local path 'vendor/bundle'
 		ynh_exec_as $app $ynh_ruby_load_path bin/bundle config set with 'development'
-		ynh_exec_warn_less "ynh_exec_as $app $ynh_ruby_load_path bin/bundle install -j$(getconf _NPROCESSORS_ONLN) --quiet"
-		ynh_exec_warn_less "ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile"
-		ynh_exec_warn_less "ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn bundle"
-		ynh_exec_warn_less "ynh_exec_as $app $ynh_ruby_load_path bin/bundle exec rails assets:precompile --quiet"
+		ynh_exec_warn_less ynh_exec_as $app $ynh_ruby_load_path bin/bundle install -j$(getconf _NPROCESSORS_ONLN) --quiet
+		ynh_exec_warn_less ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+		ynh_exec_warn_less ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn bundle
+		ynh_exec_warn_less ynh_exec_as $app $ynh_ruby_load_path bin/bundle exec rails assets:precompile --quiet
 	popd
 fi
 


### PR DESCRIPTION
## Problem

- Various packing linter warnings

## Solution

- Fix: linter: remove http->https redirect
- Fix: linter: remove examples from Disclaimer
- Fix: linter: remove ynh_webpath_available
- Fix: linter: remove quotes at ynh_exec_warn_less
- Fix: linter: remove example value in manifest.json
## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
